### PR TITLE
fix: inline with other model add NGSI Entity type

### DIFF
--- a/Organization/schema.json
+++ b/Organization/schema.json
@@ -17,6 +17,13 @@
     },
     {
       "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "Organization"
+          ],
+          "description": "Property. NGSI Entity type. It has to be Organization"
+        },
         "aggregateRating": {
           "type": "object",
           "description": "Property. The average rating based on multiple ratings or reviews. Privacy:'low'",


### PR DESCRIPTION
It appears that type (NGSI Entity type) is missing here. I believe all other definitions  in this Model are based of the `schema.json` Unsure how these other definitions are validated and/or updated